### PR TITLE
✨ Add Measurement From Binarized Image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,19 +29,19 @@ set(PROJECT_SOURCES
         src/eggsizerml.cpp
         src/eggsizerml.ui
         src/cannyDetect.cpp
+        src/blobDetect.cpp
+        src/measureEdges.cpp
         include/eggsizerml.h
         include/asmOpenCV.h
         include/cannyDetect.h
-        src/blobDetect.cpp
         include/blobDetect.h
+        include/measureEdges.h
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
     qt_add_executable(eggsizerML
         MANUAL_FINALIZATION
-        ${PROJECT_SOURCES}
-        src/blobDetect.cpp
-        include/blobDetect.h
+        ${PROJECT_SOURCES}  
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET eggsizerML APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/include/blobDetect.h
+++ b/include/blobDetect.h
@@ -3,6 +3,6 @@
 
 #include <opencv2/opencv.hpp>
 
-void detectBlobs(const cv::Mat &src, cv::Mat &dst);
+std::vector<double> detectBlobs(const cv::Mat &src, cv::Mat &dst, float pixToMM=100);
 
 #endif // BLOBDETECT_H

--- a/include/cannyDetect.h
+++ b/include/cannyDetect.h
@@ -5,6 +5,6 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-void autoCanny(cv::Mat src, cv::Mat *dst, float sigma=0.33);
+void autoCanny(cv::Mat *src, cv::Mat *dst);
 
 #endif // CANNYDETECT_H

--- a/include/eggsizerml.h
+++ b/include/eggsizerml.h
@@ -36,10 +36,6 @@ private slots:
     bool loadFile(const QString &fileName);
     // < ---------------------------------------- >
 
-    void on_cannySigmaSlider_sliderMoved(int position);
-    void on_blobDetect_btn_clicked();
-
-
 private:
     Ui::eggsizerML *ui;
 };

--- a/include/measureEdges.h
+++ b/include/measureEdges.h
@@ -1,0 +1,12 @@
+#ifndef MEASUREEDGES_H
+#define MEASUREEDGES_H
+
+// opencv inclusions
+#include <opencv2/core/core.hpp>
+#include <opencv2/core/types.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst);
+
+#endif // MEASUREEDGES_H

--- a/include/measureEdges.h
+++ b/include/measureEdges.h
@@ -4,6 +4,6 @@
 // opencv inclusions
 #include <opencv2/imgproc/imgproc.hpp>
 
-void polyApproxFromEdges(cv::Mat* thresholded, cv::Mat* orig, cv::Mat* dst);
+std::vector<double> polyApproxFromEdges(cv::Mat* thresholded, cv::Mat* orig, cv::Mat* dst, float pixToMM=100);
 
 #endif // MEASUREEDGES_H

--- a/include/measureEdges.h
+++ b/include/measureEdges.h
@@ -2,11 +2,8 @@
 #define MEASUREEDGES_H
 
 // opencv inclusions
-#include <opencv2/core/core.hpp>
-#include <opencv2/core/types.hpp>
-#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst);
+void polyApproxFromEdges(cv::Mat* thresholded, cv::Mat* orig, cv::Mat* dst);
 
 #endif // MEASUREEDGES_H

--- a/src/blobDetect.cpp
+++ b/src/blobDetect.cpp
@@ -1,6 +1,6 @@
 #include "../include/blobDetect.h"
 
-void detectBlobs(const cv::Mat &src, cv::Mat &dst) {
+std::vector<double> detectBlobs(const cv::Mat &src, cv::Mat &dst, float pixToMM) {
     // Convert to grayscale if necessary
     cv::Mat gray;
     if (src.channels() == 3) {
@@ -28,4 +28,12 @@ void detectBlobs(const cv::Mat &src, cv::Mat &dst) {
     // Draw detected blobs
     dst = src.clone();
     cv::drawKeypoints(src, keypoints, dst, cv::Scalar(0, 0, 255), cv::DrawMatchesFlags::DRAW_RICH_KEYPOINTS);
+
+    // return vector of blob areas
+    std::vector<double> blob_areas;
+    for (const auto &keypoint : keypoints) {
+        blob_areas.push_back((keypoint.size * keypoint.size * 3.14) / (4 * pixToMM));
+    }
+
+    return blob_areas;
 }

--- a/src/cannyDetect.cpp
+++ b/src/cannyDetect.cpp
@@ -1,36 +1,19 @@
 #include "../include/cannyDetect.h"
 #include <opencv2/imgproc/imgproc.hpp>
-#include <algorithm>  // for std::nth_element
 
-double computeMedian(cv::Mat channel) {
-    std::vector<uchar> pixels;
-    pixels.assign(channel.datastart, channel.dataend);
-
-    size_t n = pixels.size() / 2;
-    std::nth_element(pixels.begin(), pixels.begin() + n, pixels.end());
-    return pixels[n];
-}
-
-void autoCanny(cv::Mat src, cv::Mat *dst, float sigma) {
+void autoCanny(cv::Mat *src, cv::Mat *dst) {
     // Convert to grayscale if necessary
     cv::Mat gray;
-    if (src.channels() == 3) {
-        cv::cvtColor(src, gray, cv::COLOR_BGR2GRAY);
+    if (src->channels() == 3) {
+        cv::cvtColor(*src, gray, cv::COLOR_BGR2GRAY);
     } else {
-        gray = src.clone();
+        gray = src->clone();
     }
 
     // Apply Gaussian Blur to reduce noise
     cv::Mat blurred;
-    cv::GaussianBlur(gray, blurred, cv::Size(5, 5), sigma);
+    cv::GaussianBlur(gray, blurred, cv::Size(5, 5), 0.33);
 
-    // Compute median of the blurred image
-    double v = computeMedian(blurred);
-
-    // Calculate threshold values
-    double lower = std::max(0.0, (1.0 - sigma) * v);
-    double upper = std::min(255.0, (1.0 + sigma) * v);
-
-    // Apply Canny edge detection
-    cv::Canny(blurred, *dst, lower, upper);
+    // Apply Otsu's edge detection
+    cv::threshold(blurred, *dst, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 }

--- a/src/eggsizerml.cpp
+++ b/src/eggsizerml.cpp
@@ -7,21 +7,16 @@
 
 // GLOBAL APPLICATION DATA STORAGE
 //(keep this to a MINIMUM)
-cv::Mat src; // current image, unanalyzed
-cv::Mat dst; // current image, analyzed
-cv::Mat blobDst;
+cv::Mat orig; // original image
+cv::Mat cannyDst; // canny-detected image
+cv::Mat polyDst; // polygonally-approximated image
+cv::Mat blobDst; // blob-detected image
 
 eggsizerML::eggsizerML(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::eggsizerML)
 {
     ui->setupUi(this);
-    ui->cannySigmaSlider->setSliderPosition(33);
-    ui->sigma_val_label->setText(QString::number(ui->cannySigmaSlider->value() / 100.0f ));
-    ui->cannySigmaSlider->setDisabled(1);
-
-    connect(ui->blobDetect_btn, &QPushButton::clicked, this, &eggsizerML::on_blobDetect_btn_clicked);
-
 }
 
 eggsizerML::~eggsizerML()
@@ -71,21 +66,32 @@ void eggsizerML::open()
 // loads file into label element & CV mat for analysis
 bool eggsizerML::loadFile(const QString &fileName="")
 {
+    // validate file and read in
     QImageReader reader(fileName);
     reader.setAutoTransform(true);
-    const QImage newImage = reader.read();
-    if (newImage.isNull()) {
+    const QImage originalImage = reader.read();
+    if (originalImage.isNull()) {
         QMessageBox::information(this, QGuiApplication::applicationDisplayName(),
                                  tr("Cannot load %1, %2").arg(QDir::toNativeSeparators(fileName), reader.errorString()));
         return false;
     }
-    ui->imgDisp_1->setPixmap(QPixmap::fromImage(newImage));
-    src = cv::imread(fileName.toStdString());
-    autoCanny(src, &dst);
-    cv::Mat newdst;
-    polyApproxFromEdges(&dst, &newdst);
-    ui->imgDisp_2->setPixmap(ASM::cvMatToQPixmap(dst));
-    ui->cannySigmaSlider->setDisabled(0);
+
+    // display input image
+    ui->imgDisp_ul->setPixmap(QPixmap::fromImage(originalImage));
+
+    // Otsu's threshold and display
+    orig = cv::imread(fileName.toStdString());
+    autoCanny(&orig, &cannyDst);
+    ui->imgDisp_ll->setPixmap(ASM::cvMatToQPixmap(cannyDst));
+
+    // polygonally approximate and display
+    polyApproxFromEdges(&cannyDst, &polyDst, &orig);
+    ui->imgDisp_lr->setPixmap(ASM::cvMatToQPixmap(polyDst));
+
+    // blob detect and display
+    detectBlobs(orig, blobDst);
+    ui->imgDisp_ur->setPixmap(ASM::cvMatToQPixmap(blobDst));
+
     return true;
 }
 
@@ -94,30 +100,6 @@ bool eggsizerML::loadFile(const QString &fileName="")
 
 // < ---------------------------------------- >
 // SLOT CONNECTORS (BASICALLY CALLBACKS)
-void eggsizerML::on_cannySigmaSlider_sliderMoved(int position)
-{
-    if (!src.empty()) {
-        float newSigma = ui->cannySigmaSlider->value() / 100.0f;
-        ui->sigma_val_label->setText(QString::number(newSigma));
-        autoCanny(src, &dst, newSigma);
-        ui->imgDisp_2->setPixmap(ASM::cvMatToQPixmap(dst));
-    }
-}
-
-void eggsizerML::on_blobDetect_btn_clicked()
-{
-    if (src.empty()) {
-        QMessageBox::warning(this, "Warning", "Please open an image first!");
-        return;
-    }
-
-    // blob detection
-    detectBlobs(src, blobDst);
-
-    // display result
-    ui->imgDisp_2->setPixmap(ASM::cvMatToQPixmap(blobDst));
-}
-
 void eggsizerML::on_fileOpen_btn_clicked()
 {
     open();

--- a/src/eggsizerml.cpp
+++ b/src/eggsizerml.cpp
@@ -3,6 +3,7 @@
 #include "../include/asmOpenCV.h"
 #include "../include/cannyDetect.h"
 #include "../include/blobDetect.h"
+#include "../include/measureEdges.h"
 
 // GLOBAL APPLICATION DATA STORAGE
 //(keep this to a MINIMUM)
@@ -81,6 +82,8 @@ bool eggsizerML::loadFile(const QString &fileName="")
     ui->imgDisp_1->setPixmap(QPixmap::fromImage(newImage));
     src = cv::imread(fileName.toStdString());
     autoCanny(src, &dst);
+    cv::Mat newdst;
+    polyApproxFromEdges(&dst, &newdst);
     ui->imgDisp_2->setPixmap(ASM::cvMatToQPixmap(dst));
     ui->cannySigmaSlider->setDisabled(0);
     return true;

--- a/src/eggsizerml.cpp
+++ b/src/eggsizerml.cpp
@@ -85,12 +85,33 @@ bool eggsizerML::loadFile(const QString &fileName="")
     ui->imgDisp_ll->setPixmap(ASM::cvMatToQPixmap(cannyDst));
 
     // polygonally approximate and display
-    polyApproxFromEdges(&cannyDst, &polyDst, &orig);
+    std::vector<double> otsus_areas = polyApproxFromEdges(&cannyDst, &polyDst, &orig);
     ui->imgDisp_lr->setPixmap(ASM::cvMatToQPixmap(polyDst));
 
+    ui->tableWidget->resizeColumnsToContents();
+    ui->tableWidget->resizeRowsToContents();
+
     // blob detect and display
-    detectBlobs(orig, blobDst);
+    std::vector<double> blob_areas = detectBlobs(orig, blobDst);
     ui->imgDisp_ur->setPixmap(ASM::cvMatToQPixmap(blobDst));
+
+    // display all areas to table (first column egg no, second otsus area, third blob area)
+    int numRows = std::max(otsus_areas.size(), blob_areas.size());
+    ui->tableWidget->setRowCount(numRows);
+    for (int i = 0; i < numRows; i++) {
+        QTableWidgetItem *item1 = new QTableWidgetItem(QString::number(i + 1));
+        ui->tableWidget->setItem(i, 0, item1);
+
+        if (i < otsus_areas.size()) {
+            QTableWidgetItem *item2 = new QTableWidgetItem(QString::number(otsus_areas[i]));
+            ui->tableWidget->setItem(i, 1, item2);
+        }
+
+        if (i < blob_areas.size()) {
+            QTableWidgetItem *item3 = new QTableWidgetItem(QString::number(blob_areas[i]));
+            ui->tableWidget->setItem(i, 2, item3);
+        }
+    }
 
     return true;
 }

--- a/src/eggsizerml.ui
+++ b/src/eggsizerml.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>977</width>
+    <height>774</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,8 +19,8 @@
      <rect>
       <x>10</x>
       <y>20</y>
-      <width>781</width>
-      <height>471</height>
+      <width>891</width>
+      <height>681</height>
      </rect>
     </property>
     <property name="title">
@@ -29,134 +29,167 @@
     <widget class="QPushButton" name="fileOpen_btn">
      <property name="geometry">
       <rect>
-       <x>330</x>
-       <y>70</y>
-       <width>121</width>
-       <height>61</height>
+       <x>20</x>
+       <y>40</y>
+       <width>81</width>
+       <height>41</height>
       </rect>
      </property>
      <property name="text">
       <string>Open File</string>
      </property>
     </widget>
-    <widget class="QLabel" name="label_4">
+    <widget class="QWidget" name="verticalLayoutWidget">
      <property name="geometry">
       <rect>
-       <x>30</x>
-       <y>170</y>
-       <width>111</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Uploaded Image:</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="imgDisp_2">
-     <property name="geometry">
-      <rect>
-       <x>420</x>
-       <y>200</y>
-       <width>321</width>
-       <height>231</height>
-      </rect>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::Box</enum>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_7">
-     <property name="geometry">
-      <rect>
-       <x>430</x>
-       <y>170</y>
-       <width>111</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Processed Image:</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="imgDisp_1">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>200</y>
-       <width>321</width>
-       <height>231</height>
-      </rect>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::Box</enum>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QSlider" name="cannySigmaSlider">
-     <property name="geometry">
-      <rect>
-       <x>70</x>
+       <x>10</x>
        <y>100</y>
-       <width>160</width>
-       <height>25</height>
+       <width>801</width>
+       <height>571</height>
       </rect>
      </property>
-     <property name="value">
-      <number>33</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label">
-     <property name="geometry">
-      <rect>
-       <x>40</x>
-       <y>80</y>
-       <width>131</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Current Sigma Value:</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="sigma_val_label">
-     <property name="geometry">
-      <rect>
-       <x>170</x>
-       <y>80</y>
-       <width>58</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="blobDetect_btn">
-     <property name="geometry">
-      <rect>
-       <x>340</x>
-       <y>130</y>
-       <width>100</width>
-       <height>32</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Detect Blobs</string>
-     </property>
+     <layout class="QVBoxLayout" name="image_output_disp">
+      <item>
+       <layout class="QHBoxLayout" name="image_output_u_disp">
+        <item>
+         <layout class="QVBoxLayout" name="image_output_ul_disp">
+          <item>
+           <widget class="QLabel" name="imgLabel_ul">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>15</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Uploaded Image</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="imgDisp_ul">
+            <property name="frameShape">
+             <enum>QFrame::Shape::Box</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="image_output_ur_disp">
+          <item>
+           <widget class="QLabel" name="imgLabel_ur">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>15</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Blob Processed Image</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="imgDisp_ur">
+            <property name="frameShape">
+             <enum>QFrame::Shape::Box</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="image_output_l_disp">
+        <item>
+         <layout class="QVBoxLayout" name="image_output_ll_disp">
+          <item>
+           <widget class="QLabel" name="imgLabel_ll">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>15</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Otsu's Processed Image</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="imgDisp_ll">
+            <property name="frameShape">
+             <enum>QFrame::Shape::Box</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="image_output_lr_disp">
+          <item>
+           <widget class="QLabel" name="imgLabel_lr">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>15</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Polygonally Approximated Otsu's Processed Image</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="imgDisp_lr">
+            <property name="frameShape">
+             <enum>QFrame::Shape::Box</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </widget>
   </widget>
@@ -165,7 +198,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>977</width>
      <height>37</height>
     </rect>
    </property>

--- a/src/eggsizerml.ui
+++ b/src/eggsizerml.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>977</width>
+    <width>1105</width>
     <height>774</height>
    </rect>
   </property>
@@ -19,7 +19,7 @@
      <rect>
       <x>10</x>
       <y>20</y>
-      <width>891</width>
+      <width>1081</width>
       <height>681</height>
      </rect>
     </property>
@@ -39,155 +39,190 @@
       <string>Open File</string>
      </property>
     </widget>
-    <widget class="QWidget" name="verticalLayoutWidget">
+    <widget class="QWidget" name="horizontalLayoutWidget_3">
      <property name="geometry">
       <rect>
-       <x>10</x>
-       <y>100</y>
-       <width>801</width>
-       <height>571</height>
+       <x>-1</x>
+       <y>80</y>
+       <width>1031</width>
+       <height>591</height>
       </rect>
      </property>
-     <layout class="QVBoxLayout" name="image_output_disp">
+     <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="image_output_u_disp">
+       <layout class="QVBoxLayout" name="image_output_disp">
         <item>
-         <layout class="QVBoxLayout" name="image_output_ul_disp">
+         <layout class="QHBoxLayout" name="image_output_u_disp">
           <item>
-           <widget class="QLabel" name="imgLabel_ul">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>15</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Uploaded Image</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="image_output_ul_disp">
+            <item>
+             <widget class="QLabel" name="imgLabel_ul">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Uploaded Image</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="imgDisp_ul">
+              <property name="frameShape">
+               <enum>QFrame::Shape::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QLabel" name="imgDisp_ul">
-            <property name="frameShape">
-             <enum>QFrame::Shape::Box</enum>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="image_output_ur_disp">
+            <item>
+             <widget class="QLabel" name="imgLabel_ur">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Blob Processed Image</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="imgDisp_ur">
+              <property name="frameShape">
+               <enum>QFrame::Shape::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="image_output_ur_disp">
+         <layout class="QHBoxLayout" name="image_output_l_disp">
           <item>
-           <widget class="QLabel" name="imgLabel_ur">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>15</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Blob Processed Image</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="image_output_ll_disp">
+            <item>
+             <widget class="QLabel" name="imgLabel_ll">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Otsu's Processed Image</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="imgDisp_ll">
+              <property name="frameShape">
+               <enum>QFrame::Shape::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QLabel" name="imgDisp_ur">
-            <property name="frameShape">
-             <enum>QFrame::Shape::Box</enum>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <layout class="QVBoxLayout" name="image_output_lr_disp">
+            <item>
+             <widget class="QLabel" name="imgLabel_lr">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Polygonally Approximated Otsu's Processed Image</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="imgDisp_lr">
+              <property name="frameShape">
+               <enum>QFrame::Shape::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="image_output_l_disp">
-        <item>
-         <layout class="QVBoxLayout" name="image_output_ll_disp">
-          <item>
-           <widget class="QLabel" name="imgLabel_ll">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>15</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Otsu's Processed Image</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="imgDisp_ll">
-            <property name="frameShape">
-             <enum>QFrame::Shape::Box</enum>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="image_output_lr_disp">
-          <item>
-           <widget class="QLabel" name="imgLabel_lr">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>15</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Polygonally Approximated Otsu's Processed Image</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="imgDisp_lr">
-            <property name="frameShape">
-             <enum>QFrame::Shape::Box</enum>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
+       <widget class="QTableWidget" name="tableWidget">
+        <property name="maximumSize">
+         <size>
+          <width>300</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <attribute name="horizontalHeaderVisible">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Egg No.</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Otsu's Size (mm)</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Blob Size (mm)</string>
+         </property>
+        </column>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -198,7 +233,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>977</width>
+     <width>1105</width>
      <height>37</height>
     </rect>
    </property>

--- a/src/measureEdges.cpp
+++ b/src/measureEdges.cpp
@@ -1,0 +1,27 @@
+#include "../include/measureEdges.h"
+
+void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst) {
+    // copy over src for comparison
+    *dst = *src;
+
+    // contour pre-processed image
+    std::vector<std::vector<cv::Point>> contours;
+    findContours(*src, contours, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
+
+    // draw contours onto image
+    for (int i = 0; i < contours.size(); i++) {
+        // very roughly approximately connect contours to form a closed shape
+        std::vector<cv::Point> approx;
+        approxPolyDP(contours[i], approx, 0.005 * arcLength(contours[i], true), true);
+
+        // if the contour is a closed shape
+        if (contourArea(contours[i]) >= 18000 && contourArea(contours[i]) <= 700000) {
+            // draw the contour
+            drawContours(*dst, std::vector<std::vector<cv::Point>>{approx}, 0, cv::Scalar(255, 0, 0), 2);
+
+            // calculate the area of the poly-dp approximated contour
+            // egg_areas.push_back(contourArea(approx));
+        }
+    }
+    imshow("Poly-Approx Image", *dst);
+}

--- a/src/measureEdges.cpp
+++ b/src/measureEdges.cpp
@@ -1,8 +1,9 @@
 #include "../include/measureEdges.h"
 
-void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst) {
-    // copy over src for comparison
-    *dst = *src;
+void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst, cv::Mat* orig) {
+    // copy orig to dst to display contours on copy
+    // of original image
+    *dst = orig->clone();
 
     // contour pre-processed image
     std::vector<std::vector<cv::Point>> contours;
@@ -17,11 +18,10 @@ void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst) {
         // if the contour is a closed shape
         if (contourArea(contours[i]) >= 18000 && contourArea(contours[i]) <= 700000) {
             // draw the contour
-            drawContours(*dst, std::vector<std::vector<cv::Point>>{approx}, 0, cv::Scalar(255, 0, 0), 2);
+            drawContours(*dst, std::vector<std::vector<cv::Point>>{approx}, 0, cv::Scalar(0, 150, 0), 2);
 
             // calculate the area of the poly-dp approximated contour
             // egg_areas.push_back(contourArea(approx));
         }
     }
-    imshow("Poly-Approx Image", *dst);
 }

--- a/src/measureEdges.cpp
+++ b/src/measureEdges.cpp
@@ -1,9 +1,9 @@
 #include "../include/measureEdges.h"
 
-void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst, cv::Mat* orig) {
-    // copy orig to dst to display contours on copy
-    // of original image
+std::vector<double> polyApproxFromEdges(cv::Mat* src, cv::Mat* dst, cv::Mat* orig, float pixToMM) {
+    // set up output mat + array
     *dst = orig->clone();
+    std::vector<double> egg_areas;
 
     // contour pre-processed image
     std::vector<std::vector<cv::Point>> contours;
@@ -21,7 +21,9 @@ void polyApproxFromEdges(cv::Mat* src, cv::Mat* dst, cv::Mat* orig) {
             drawContours(*dst, std::vector<std::vector<cv::Point>>{approx}, 0, cv::Scalar(0, 150, 0), 2);
 
             // calculate the area of the poly-dp approximated contour
-            // egg_areas.push_back(contourArea(approx));
+            egg_areas.push_back(contourArea(approx) / pixToMM);
         }
     }
+
+    return egg_areas;
 }


### PR DESCRIPTION
Modified our two object detection functions to work such that they return a vector of doubles for egg areas. Also added a basic table widget to display the measured size of eggs in mm. The default Pixel to MM ratio is assumed to be 100 but we will add an optional input from the user in the future. I would also like to add sample ID markers (i.e. drawing a 1,2,3) on detected objects so measurements are perfectly traceable in output, but this is all I'm doing on this branch to keep encapsulation to a minimum.